### PR TITLE
Fix empty fraction in estimate_initial_parameters_and_bounds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -94,6 +94,11 @@ The format is based on `Keep a Changelog
   ``nicholaslourie.github.io/opda``. Update the project URLs in
   ``pyproject.toml`` and all the links throughout the repository to
   reflect these changes.
+* Require ``fraction`` is greater than 0 in
+  ``opda.parametric.QuadraticDistribution.estimate_initial_parameters_and_bounds``.
+* Throw an error if ``fraction`` is too small and thus causes
+  ``opda.parametric.QuadraticDistribution.estimate_initial_parameters_and_bounds`` to
+  try and form an estimate from an empty list.
 
 .. rubric:: Deprecations
 .. rubric:: Removals
@@ -103,6 +108,12 @@ The format is based on `Keep a Changelog
   and ``.estimate_initial_parameters_and_bounds`` methods) for the
   case when ``a == b``, in which case the distribution is an atom
   (point mass).
+* Fix
+  ``opda.parametric.QuadraticDistribution.estimate_initial_parameters_and_bounds``
+  when ``convex`` is ``False`` and ``fraction`` is small enough so
+  that the estimate should be based on an empty list. In this case,
+  the method incorrectly uses all of ``ys``. Instead, throw an error
+  saying that fraction is too small (as it produces an empty list).
 
 .. rubric:: Documentation
 

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -414,7 +414,7 @@ class QuadraticDistribution:
         ys : 1D array of floats, required
             The sample from which to estimate the initial parameters and
             bounds.
-        fraction : float (0. <= fraction <= 1.), optional (default=1.)
+        fraction : float (0. < fraction <= 1.), optional (default=1.)
             The fraction of the sample to use. If ``convex`` is
             ``False``, the greatest ``fraction`` numbers are
             retained. If ``convex`` is ``True``, the least ``fraction``
@@ -439,9 +439,9 @@ class QuadraticDistribution:
         fraction = np.array(fraction)[()]
         if not np.isscalar(fraction):
             raise ValueError("fraction must be a scalar.")
-        if fraction < 0. or fraction > 1.:
+        if fraction <= 0. or fraction > 1.:
             raise ValueError(
-                "fraction must be between 0 and 1, inclusive.",
+                "fraction must be between 0 and 1, inclusive of 1.",
             )
 
         if not isinstance(convex, bool):

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -448,10 +448,16 @@ class QuadraticDistribution:
             raise TypeError("convex must be a boolean.")
 
         # Compute the initial parameters and bounds.
+        n_fraction = int(fraction * len(ys))
+        if n_fraction == 0:
+            raise ValueError(
+                "Taking fraction from ys makes an empty list. Raise"
+                " fraction or use a larger sample for ys.",
+            )
         ys_fraction = (
-            np.sort(ys)[:int(fraction * len(ys))]
+            np.sort(ys)[:n_fraction]
             if convex else
-            np.sort(ys)[-int(fraction * len(ys)):]
+            np.sort(ys)[-n_fraction:]
         )
 
         a = ys_fraction[0]

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -865,6 +865,51 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
 
         # Test error conditions.
         for convex in [False, True]:
+            # when ys is not 1D
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        0,
+                        fraction=0.5,
+                        convex=convex,
+                    )
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [[0]],
+                        fraction=0.5,
+                        convex=convex,
+                    )
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [[0], [1]],
+                        fraction=0.5,
+                        convex=convex,
+                    )
+            # when ys is empty
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [],
+                        fraction=0.5,
+                        convex=convex,
+                    )
+            # when fraction is not a scalar
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2, 3, 4, 5],
+                        fraction=[0.5],
+                        convex=convex,
+                    )
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2, 3, 4, 5],
+                        fraction=[[0.5]],
+                        convex=convex,
+                    )
             # when fraction is not between 0 and 1, inclusive of 1
             with self.assertRaises(ValueError):
                 parametric.QuadraticDistribution\
@@ -886,6 +931,28 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
                         [0, 1, 2, 3, 4, 5],
                         fraction=1.1,
                         convex=convex,
+                    )
+            # when convex is not a bool
+            with self.assertRaises(TypeError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2, 3, 4, 5],
+                        fraction=0.5,
+                        convex=None,
+                    )
+            with self.assertRaises(TypeError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2, 3, 4, 5],
+                        fraction=0.5,
+                        convex=0.,
+                    )
+            with self.assertRaises(TypeError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2, 3, 4, 5],
+                        fraction=0.5,
+                        convex=[True],
                     )
 
     def test_sample_defaults_to_global_random_number_generator(self):

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -863,6 +863,31 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
                     self.assertGreaterEqual(c, bounds[2, 0])
                     self.assertLessEqual(c, bounds[2, 1])
 
+        # Test error conditions.
+        for convex in [False, True]:
+            # when fraction is not between 0 and 1, inclusive of 1
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2, 3, 4, 5],
+                        fraction=-0.1,
+                        convex=convex,
+                    )
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2, 3, 4, 5],
+                        fraction=0.,
+                        convex=convex,
+                    )
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2, 3, 4, 5],
+                        fraction=1.1,
+                        convex=convex,
+                    )
+
     def test_sample_defaults_to_global_random_number_generator(self):
         # sample should be deterministic if global seed is set.
         dist = parametric.QuadraticDistribution(0., 1., 2)

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -954,6 +954,28 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
                         fraction=0.5,
                         convex=[True],
                     )
+            # when fraction * len(ys) < 1
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0],
+                        fraction=0.99,
+                        convex=convex,
+                    )
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1],
+                        fraction=0.49,
+                        convex=convex,
+                    )
+            with self.assertRaises(ValueError):
+                parametric.QuadraticDistribution\
+                    .estimate_initial_parameters_and_bounds(
+                        [0, 1, 2],
+                        fraction=0.32,
+                        convex=convex,
+                    )
 
     def test_sample_defaults_to_global_random_number_generator(self):
         # sample should be deterministic if global seed is set.


### PR DESCRIPTION
Throw errors in cases where `fraction` causes `QuadraticDistribution.estimate_initial_parameters_and_bounds` to try and make an estimate from an empty list.