### PR TITLE
Fix warning in dkw epsilon

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,6 +75,8 @@ The format is based on `Keep a Changelog
 * Add ``opda.parametric.NoisyQuadraticDistribution``, a probability
   distribution representing a quadratic random variable plus normal
   noise.
+* Increase argument validation in ``opda.utils.dkw_epsilon``.
+* Add more test cases for ``opda.utils.dkw_epsilon``.
 
 .. rubric:: Changes
 
@@ -114,6 +116,8 @@ The format is based on `Keep a Changelog
   that the estimate should be based on an empty list. In this case,
   the method incorrectly uses all of ``ys``. Instead, throw an error
   saying that fraction is too small (as it produces an empty list).
+* Avoid throwing an unnecessary warning in ``opda.utils.dkw_epsilon``
+  when ``confidence`` is 1.
 
 .. rubric:: Documentation
 

--- a/src/opda/utils.py
+++ b/src/opda/utils.py
@@ -74,6 +74,9 @@ def dkw_epsilon(n, confidence):
         )
 
     # Compute the DKW epsilon.
+    if confidence == 1.:
+        return np.inf
+
     return np.sqrt(
         np.log(2. / (1. - confidence))
         / (2. * n),

--- a/src/opda/utils.py
+++ b/src/opda/utils.py
@@ -59,12 +59,16 @@ def dkw_epsilon(n, confidence):
         The epsilon for the Dvoretzky-Kiefer-Wolfowitz inequality.
     """
     # Validate the arguments.
-    n = np.array(n)
+    n = np.array(n)[()]
+    if not np.isscalar(n):
+        raise ValueError("n must be a scalar.")
     if n <= 0:
         raise ValueError("n must be positive.")
 
-    confidence = np.array(confidence)
-    if np.any((confidence < 0.) | (confidence > 1.)):
+    confidence = np.array(confidence)[()]
+    if not np.isscalar(confidence):
+        raise ValueError("confidence must be a scalar.")
+    if confidence < 0. or confidence > 1.:
         raise ValueError(
             "confidence must be between 0 and 1, inclusive.",
         )

--- a/tests/opda/test_utils.py
+++ b/tests/opda/test_utils.py
@@ -112,6 +112,28 @@ class DkwEpsilonTestCase(unittest.TestCase):
         self.assertAlmostEqual(utils.dkw_epsilon(1, 1. - 2./np.e**2), 1.)
         self.assertAlmostEqual(utils.dkw_epsilon(4, 1. - 2./np.e**2), 0.5)
 
+        # Test error conditions.
+        #   when n is not a scalar
+        with self.assertRaises(ValueError):
+            utils.dkw_epsilon([1], 0.5)
+        with self.assertRaises(ValueError):
+            utils.dkw_epsilon([[1]], 0.5)
+        #   when n is not positive
+        with self.assertRaises(ValueError):
+            utils.dkw_epsilon(0, 0.5)
+        with self.assertRaises(ValueError):
+            utils.dkw_epsilon(-1, 0.5)
+        #   when confidence is not a scalar
+        with self.assertRaises(ValueError):
+            utils.dkw_epsilon(10, [0.5])
+        with self.assertRaises(ValueError):
+            utils.dkw_epsilon(10, [[0.5]])
+        #   when confidence is not between 0 and 1, inclusive
+        with self.assertRaises(ValueError):
+            utils.dkw_epsilon(10, -0.1)
+        with self.assertRaises(ValueError):
+            utils.dkw_epsilon(10, 1.1)
+
 
 class BetaEqualTailedIntervalTestCase(testcases.RandomTestCase):
     """Test opda.utils.beta_equal_tailed_interval."""

--- a/tests/opda/test_utils.py
+++ b/tests/opda/test_utils.py
@@ -107,6 +107,19 @@ class DkwEpsilonTestCase(unittest.TestCase):
     """Test opda.utils.dkw_epsilon."""
 
     def test_dkw_epsilon(self):
+        # Test when confidence = 0.
+        self.assertEqual(utils.dkw_epsilon(1, 0.), np.sqrt(np.log(2) / 2))
+        self.assertEqual(utils.dkw_epsilon(2, 0.), np.sqrt(np.log(2) / 4))
+        self.assertEqual(utils.dkw_epsilon(4, 0.), np.sqrt(np.log(2) / 8))
+        self.assertEqual(utils.dkw_epsilon(8, 0.), np.sqrt(np.log(2) / 16))
+
+        # Test when confidence = 1.
+        self.assertEqual(utils.dkw_epsilon(1, 1.), np.inf)
+        self.assertEqual(utils.dkw_epsilon(2, 1.), np.inf)
+        self.assertEqual(utils.dkw_epsilon(4, 1.), np.inf)
+        self.assertEqual(utils.dkw_epsilon(8, 1.), np.inf)
+
+        # Test when 0 < confidence < 1.
         self.assertAlmostEqual(utils.dkw_epsilon(2, 1. - 2./np.e), 0.5)
         self.assertAlmostEqual(utils.dkw_epsilon(8, 1. - 2./np.e), 0.25)
         self.assertAlmostEqual(utils.dkw_epsilon(1, 1. - 2./np.e**2), 1.)


### PR DESCRIPTION
Fix `opda.utils.dkw_epsilon` in the case when `confidence = 1.`. While the function returns the correct answer, it throws an unnecessary division by zero warning.