### PR TITLE
Add support for numpy 2.0 and scipy 1.13

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,9 @@ The format is based on `Keep a Changelog
 `Unreleased`_
 =============
 .. rubric:: Additions
+
+* Add support for ``numpy == 2.0`` and ``scipy == 1.13``.
+
 .. rubric:: Changes
 .. rubric:: Deprecations
 .. rubric:: Removals

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,8 +35,8 @@ SUPPORTED_PYTHON_VERSIONS = {"3.8", "3.9", "3.10", "3.11", "3.12"}
 """All Python versions currently supported by opda."""
 
 SUPPORTED_PACKAGE_VERSIONS = {
-    "numpy": {"1.21", "1.22", "1.23", "1.24", "1.25", "1.26"},
-    "scipy": {"1.8", "1.9", "1.10", "1.11", "1.12"},
+    "numpy": {"1.21", "1.22", "1.23", "1.24", "1.25", "1.26", "2.0"},
+    "scipy": {"1.8", "1.9", "1.10", "1.11", "1.12", "1.13"},
 }
 """All core package versions currently supported by opda."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,15 +3,16 @@
 import datetime
 import itertools
 import json
+import logging
 import os
 import pathlib
 import re
 import shutil
 import tempfile
-import urllib.request
 
 from lxml import etree
 import nox
+import requests
 
 # backwards compatibility (Python < 3.11)
 
@@ -69,8 +70,8 @@ def fetch_supported_python_versions():
     versions that still receive security updates.
     """
     # Get currently supported python versions from the downloads page.
-    request = urllib.request.urlopen("https://www.python.org/downloads/")
-    root = etree.parse(request, parser=etree.HTMLParser())
+    response = requests.get("https://www.python.org/downloads/", timeout=30)
+    root = etree.fromstring(response.content, parser=etree.HTMLParser())
 
     supported_versions = set()
     for element in root.xpath(
@@ -92,10 +93,8 @@ def fetch_supported_package_versions(package):
     opda's support policy is to maintain compatibility with core
     packages' feature releases for 2 years.
     """
-    request = urllib.request.urlopen(  # noqa: S310
-        f"https://pypi.org/pypi/{package}/json",
-    )
-    version_to_release = json.load(request)["releases"]
+    response = requests.get(f"https://pypi.org/pypi/{package}/json", timeout=30)
+    version_to_release = json.loads(response.content)["releases"]
 
     supported_versions = set()
     for version, release in version_to_release.items():
@@ -138,6 +137,12 @@ def uninstall_all_packages(session):
         "--yes",
         *requirements.split("\n"),
     )
+
+
+# logging configuration
+
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 # nox configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ package = [
 ci = [
   "lxml == 5.1.0",
   "nox == 2023.4.22",
+  "requests == 2.31.0",
   "tomli; python_version<'3.11'",  # backwards compatibility (Python < 3.11)
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ package = [
   "twine == 4.0.2",
 ]
 ci = [
-  "nox == 2023.4.22",
   "lxml == 5.1.0",
+  "nox == 2023.4.22",
   "tomli; python_version<'3.11'",  # backwards compatibility (Python < 3.11)
 ]
 


### PR DESCRIPTION
Begin testing the package against numpy 2.0 and scipy 1.13.

Also, fix an unrelated issue in the `support` nox session. Python.org has begun returning gzipped content even when the request headers don't ask for it, so update the `support` session to handle this edge case.