### PR TITLE
Make scale the standard deviation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,11 @@ The format is based on `Keep a Changelog
 =============
 .. rubric:: Additions
 .. rubric:: Changes
+
+* Simplify the implementation of
+  ``opda.parametric.NoisyQuadraticDistribution`` by making ``scale``
+  the standard deviation of the corresponding normal random variable.
+
 .. rubric:: Deprecations
 .. rubric:: Removals
 


### PR DESCRIPTION
In the implementation of ``opda.parametric.NoisyQuadraticDistribution``, make `scale` the standard deviation of the corresponding normal distribution rather than a multiplier of it (which could be positive or negative).

This change conceptually simplifies the code, making it easier to understand.