### PR TITLE
Add `C_MIN` and `C_MAX` class attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,8 @@ The format is based on `Keep a Changelog
   * Add a README for the data: ``data/resnet/README.md``.
 
 * Add support for ``scipy == 1.14``.
+* Add the ``C_MIN`` and ``C_MAX`` class attributes to
+  ``opda.parametric.NoisyQuadraticDistribution``.
 
 .. rubric:: Changes
 

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -438,6 +438,10 @@ class NoisyQuadraticDistribution:
         The distribution's mean.
     variance : float
         The distribution's variance.
+    C_MIN : int
+        A class attribute giving the minimum supported value of ``c``.
+    C_MAX : int
+        A class attribute giving the maximum supported value of ``c``.
 
     See Also
     --------
@@ -474,6 +478,8 @@ class NoisyQuadraticDistribution:
     deviation, :math:`\sigma`.
     """
 
+    C_MIN, C_MAX = 1, 10
+
     def __init__(
             self,
             a,
@@ -502,9 +508,10 @@ class NoisyQuadraticDistribution:
             raise ValueError("c must be an integer.")
         if c <= 0:
             raise ValueError("c must be positive.")
-        if c > 10:
+        if c < self.C_MIN or c > self.C_MAX:
             raise ValueError(
-                "Values of c greater than 10 are not supported.",
+                f"Values of c less than {self.C_MIN} or greater than"
+                f" {self.C_MAX} are not supported.",
             )
 
         o = np.array(o)[()]

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -1046,6 +1046,28 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
 class NoisyQuadraticDistributionTestCase(testcases.RandomTestCase):
     """Test opda.parametric.NoisyQuadraticDistribution."""
 
+    def test_class_attributes(self):
+        # Test C_MIN and C_MAX.
+
+        c_min = parametric.NoisyQuadraticDistribution.C_MIN
+        c_max = parametric.NoisyQuadraticDistribution.C_MAX
+
+        # NoisyQuadraticDistribution should always support c = 1 to 5.
+        self.assertEqual(c_min, 1)
+        self.assertGreaterEqual(c_max, 5)
+
+        # NoisyQuadraticDistribution should support all claimed values of c.
+        for c in range(c_min, c_max + 1):
+            dist = parametric.NoisyQuadraticDistribution(0., 1., c, 1e-2, False)
+            self.assertGreater(dist.pdf(0.5), 0.)
+            self.assertGreater(dist.cdf(0.5), 0.)
+
+        # C_MAX should match the maximum value for c mentioned in the docstring.
+        self.assertIn(
+            f"Values of ``c`` greater than {c_max} are not supported.",
+            " ".join(parametric.NoisyQuadraticDistribution.__doc__.split()),
+        )
+
     @pytest.mark.level(2)
     def test_attributes(self):
         n_samples = 1_000_000


### PR DESCRIPTION
Add the `C_MIN` and `C_MAX` class attributes to `opda.parametric.NoisyQuadraticDistribution`.