### PR TITLE
Use approximations in `NoisyQuadraticDistribution.ppf`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,8 @@ The format is based on `Keep a Changelog
 * Add support for ``scipy == 1.14``.
 * Add the ``C_MIN`` and ``C_MAX`` class attributes to
   ``opda.parametric.NoisyQuadraticDistribution``.
+* Add ``opda.utils.normal_ppf``, a fast function for computing the
+  standard normal's PPF (quantile function).
 
 .. rubric:: Changes
 
@@ -67,6 +69,8 @@ The format is based on `Keep a Changelog
   ``opda.utils.beta_equal_tailed_coverage`` when they fail due to
   `an issue <https://github.com/scipy/scipy/issues/21303>`_  in
   ``scipy == 1.14.0`` on Linux that causes spurious NaN values.
+* Use the point mass, noiseless, and normal approximations to speed up
+  the ``ppf`` method of ``opda.parametric.NoisyQuadraticDistribution``.
 
 .. rubric:: Deprecations
 .. rubric:: Removals
@@ -82,8 +86,15 @@ The format is based on `Keep a Changelog
   ``opda.parametric.QuadraticDistribution``, and
   ``opda.parametric.NoisyQuadraticDistribution`` so that they're
   compatible with ``numpy == 2.0``.
+* Fix flakiness in the test:
+  ``NoisyQuadraticDistributionTestCase.test_ppf_is_inverse_of_cdf``.
 
 .. rubric:: Documentation
+
+* Correct the quantile function's definition in the docstrings for the
+  ``ppf`` methods of ``opda.parametric.QuadraticDistribution`` and
+  ``opda.parametric.NoisyQuadraticDistribution``.
+
 .. rubric:: Security
 
 

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -266,9 +266,11 @@ class QuadraticDistribution:
 
         .. math::
 
-           Q(p) = \inf \{y\in[a, b]\mid p\leq F(y)\}
+           Q(p) = \inf \{y\in\operatorname{supp} f(y)\mid p\leq F(y)\}
 
-        where :math:`F` is the cumulative distribution function.
+        where :math:`f` is the probability density, :math:`F` is the
+        cumulative distribution function, and
+        :math:`\operatorname{supp} f(y)` is the support.
 
         Parameters
         ----------
@@ -763,9 +765,11 @@ class NoisyQuadraticDistribution:
 
         .. math::
 
-           Q(p) = \inf \{y\in\mathbb{R}\mid p\leq F(y)\}
+           Q(p) = \inf \{y\in\operatorname{supp} f(y)\mid p\leq F(y)\}
 
-        where :math:`F` is the cumulative distribution function.
+        where :math:`f` is the probability density, :math:`F` is the
+        cumulative distribution function, and
+        :math:`\operatorname{supp} f(y)` is the support.
 
         Parameters
         ----------

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -787,9 +787,25 @@ class NoisyQuadraticDistribution:
             raise ValueError("qs must be between 0 and 1, inclusive.")
         qs = np.clip(qs, 0., 1.)
 
-        # Compute the quantiles.
+        a, b, c, o = self.a, self.b, self.c, self.o
 
-        a, b, o = self.a, self.b, self.o
+        # Use approximations if appropriate.
+
+        if a == b and o == 0.:
+            return np.full_like(qs, a)[()]
+
+        if self._approximate_with == "noiseless":
+            if self.convex:
+                ys = a + (b - a) * qs**(2/c)
+            else:  # concave
+                ys = b - (b - a) * (1 - qs)**(2/c)
+
+            return ys
+
+        if self._approximate_with == "normal":
+            return self.mean + self.variance**0.5 * utils.normal_ppf(qs)
+
+        # Compute the quantiles.
 
         # Numerically invert the CDF with the bisection method.
         ys_lo = np.full_like(qs, a - 6 * o)

--- a/src/opda/utils.py
+++ b/src/opda/utils.py
@@ -546,3 +546,32 @@ def normal_cdf(xs):
     xs = np.array(xs)
 
     return 0.5 * (1. + special.erf(1 / 2**0.5 * xs))
+
+
+def normal_ppf(qs):
+    """Evaluate the PPF of the standard normal distribution.
+
+    Parameters
+    ----------
+    qs : float or array of floats from 0 to 1 inclusive, required
+        The points at which to evaluate the standard normal
+        distribution's quantile function.
+
+    Returns
+    -------
+    float or array of floats
+        The standard normal distribution's quantile function evaluated
+        at ``qs``.
+    """
+    # NOTE: In a quick benchmark, this implementation was 2-6x faster
+    # than scipy.stats.norm.ppf at moderate input sizes (1-1k) and 1.25x
+    # slower at very large sizes (100k-1M).
+
+    # Validate the arguments.
+    qs = np.array(qs)
+    if np.any((qs < 0. - 1e-10) | (qs > 1. + 1e-10)):
+        raise ValueError("qs must be between 0 and 1, inclusive.")
+    qs = np.clip(qs, 0., 1.)
+
+    # Compute the quantiles.
+    return 2**0.5 * special.erfinv(2. * qs - 1.)

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -2673,18 +2673,28 @@ class NoisyQuadraticDistributionTestCase(testcases.RandomTestCase):
                         )
 
                         ys = dist.sample(100)
+                        qs = dist.cdf(ys)
+
+                        # Remove points where the CDF gets rounded to 0
+                        # or 1 since they'll be mapped to the lower or
+                        # upper bound on the support (-inf and inf when
+                        # o > 0) and thus won't invert.
+                        ys = ys[(0. < qs) & (qs < 1.)]
+                        qs = qs[(0. < qs) & (qs < 1.)]
 
                         ys_center = ys[(ys >= a) & (ys <= b)]
+                        qs_center = qs[(ys >= a) & (ys <= b)]
                         self.assertTrue(np.allclose(
-                            dist.ppf(dist.cdf(ys_center)),
+                            dist.ppf(qs_center),
                             ys_center,
                             atol=1e-5,
                         ))
                         # NOTE: Precision of the ppf is more difficult
                         # in the tails because the CDF is nearly flat.
                         ys_tails = ys[(ys < a) | (ys > b)]
+                        qs_tails = qs[(ys < a) | (ys > b)]
                         self.assertTrue(np.allclose(
-                            dist.ppf(dist.cdf(ys_tails)),
+                            dist.ppf(qs_tails),
                             ys_tails,
                             atol=1e-2,
                         ))

--- a/tests/opda/test_utils.py
+++ b/tests/opda/test_utils.py
@@ -1274,3 +1274,26 @@ class NormalCdfTestCase(unittest.TestCase):
         xs = np.linspace(-10., 10., num=1_000).reshape((100, 10))
         self.assertEqual(utils.normal_cdf(xs).shape, xs.shape)
         self.assertTrue(np.allclose(utils.normal_cdf(xs), norm.cdf(xs)))
+
+
+class NormalPpfTestCase(unittest.TestCase):
+    """Test opda.utils.normal_ppf."""
+
+    def test_normal_ppf(self):
+        norm = stats.norm(0., 1.)
+        # scalar
+        for q in [
+                0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.,
+                0.0000001, 0.000001, 0.00001, 0.0001, 0.001, 0.01,
+                0.9999999, 0.999999, 0.99999, 0.9999, 0.999, 0.99,
+        ]:
+            self.assertTrue(np.isscalar(utils.normal_ppf(q)))
+            self.assertAlmostEqual(utils.normal_ppf(q), norm.ppf(q))
+        # 1D array
+        qs = np.linspace(0., 1., num=1_000)
+        self.assertEqual(utils.normal_ppf(qs).shape, qs.shape)
+        self.assertTrue(np.allclose(utils.normal_ppf(qs), norm.ppf(qs)))
+        # 2D array
+        qs = np.linspace(0., 1., num=1_000).reshape((100, 10))
+        self.assertEqual(utils.normal_ppf(qs).shape, qs.shape)
+        self.assertTrue(np.allclose(utils.normal_ppf(qs), norm.ppf(qs)))


### PR DESCRIPTION
Use the point mass, noiseless, and normal approximations in `opda.parametric.NoisyQuadraticDistribution.ppf`.