### PR TITLE
Add support for numpy 2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,7 +52,7 @@ The format is based on `Keep a Changelog
   * Add a license for the data: ``data/resnet/LICENSE``.
   * Add a README for the data: ``data/resnet/README.md``.
 
-* Add support for ``scipy == 1.14``.
+* Add support for ``scipy == 1.14`` and ``numpy == 2.1``.
 * Add the ``C_MIN`` and ``C_MAX`` class attributes to
   ``opda.parametric.NoisyQuadraticDistribution``.
 * Add ``opda.utils.normal_ppf``, a fast function for computing the

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ SUPPORTED_PYTHON_VERSIONS = {"3.8", "3.9", "3.10", "3.11", "3.12"}
 """All Python versions currently supported by opda."""
 
 SUPPORTED_PACKAGE_VERSIONS = {
-    "numpy": {"1.23", "1.24", "1.25", "1.26", "2.0"},
+    "numpy": {"1.23", "1.24", "1.25", "1.26", "2.0", "2.1"},
     "scipy": {"1.9", "1.10", "1.11", "1.12", "1.13", "1.14"},
 }
 """All core package versions currently supported by opda."""


### PR DESCRIPTION
Add support for numpy 2.1 so that `opda` will test against it in continuous integration.