### PR TITLE
Update support for numpy and scipy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,9 +44,15 @@ The format is based on `Keep a Changelog
 `Unreleased`_
 =============
 .. rubric:: Additions
+
+* Add support for ``numpy == 2.2`` and ``scipy == 1.15``.
+
 .. rubric:: Changes
 .. rubric:: Deprecations
 .. rubric:: Removals
+
+* Drop support for ``numpy == 1.23``.
+
 .. rubric:: Fixes
 .. rubric:: Documentation
 .. rubric:: Security

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ SUPPORTED_PYTHON_VERSIONS = {"3.8", "3.9", "3.10", "3.11", "3.12", "3.13"}
 """All Python versions currently supported by opda."""
 
 SUPPORTED_PACKAGE_VERSIONS = {
-    "numpy": {"1.23", "1.24", "1.25", "1.26", "2.0", "2.1"},
+    "numpy": {"1.23", "1.24", "1.25", "1.26", "2.0", "2.1", "2.2"},
     "scipy": {"1.10", "1.11", "1.12", "1.13", "1.14"},
 }
 """All core package versions currently supported by opda."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ SUPPORTED_PYTHON_VERSIONS = {"3.8", "3.9", "3.10", "3.11", "3.12", "3.13"}
 """All Python versions currently supported by opda."""
 
 SUPPORTED_PACKAGE_VERSIONS = {
-    "numpy": {"1.23", "1.24", "1.25", "1.26", "2.0", "2.1", "2.2"},
+    "numpy": {"1.24", "1.25", "1.26", "2.0", "2.1", "2.2"},
     "scipy": {"1.10", "1.11", "1.12", "1.13", "1.14"},
 }
 """All core package versions currently supported by opda."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ SUPPORTED_PYTHON_VERSIONS = {"3.8", "3.9", "3.10", "3.11", "3.12", "3.13"}
 
 SUPPORTED_PACKAGE_VERSIONS = {
     "numpy": {"1.24", "1.25", "1.26", "2.0", "2.1", "2.2"},
-    "scipy": {"1.10", "1.11", "1.12", "1.13", "1.14"},
+    "scipy": {"1.10", "1.11", "1.12", "1.13", "1.14", "1.15"},
 }
 """All core package versions currently supported by opda."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.rst"
 license = {text = "Apache-2.0"}
 requires-python = ">= 3.8"
 dependencies = [
-  "numpy >= 1.23",
+  "numpy >= 1.24",
   "scipy >= 1.10",
 ]
 keywords = [


### PR DESCRIPTION
Begin testing against numpy 2.2 and scipy 1.15, and drop support for numpy 1.23.