### PR TITLE
Fix `experiments` optional dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,9 @@ The format is based on `Keep a Changelog
 * Fix support policy check in continuous integration so that it
   more accurately determines currently supported python versions.
 
+* Suppress expected deprecation warnings that ``autograd`` fires when
+  installed with certain versions of ``numpy``.
+
 .. rubric:: Documentation
 .. rubric:: Security
 

--- a/src/experiments/analytic.py
+++ b/src/experiments/analytic.py
@@ -1,8 +1,21 @@
 """Analytic approximations to random search."""
 
-from autograd import hessian
 import numpy as np
 from scipy import optimize, special
+
+# backwards compatibility (autograd < ???)
+import warnings  # ruff: isort: skip
+
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message=r"numpy.core.einsumfunc is deprecated",
+        category=DeprecationWarning,
+    )
+    # Importing autograd can raise deprecation warnings depending on
+    # the version of autograd and numpy. For example, autograd 1.7.0
+    # and numpy == 2.0.2 give a deprecation warning on import.
+    from autograd import hessian
 
 
 def ellipse_volume(cs):

--- a/src/experiments/simulation.py
+++ b/src/experiments/simulation.py
@@ -3,9 +3,23 @@
 import dataclasses
 import typing
 
-from autograd import numpy as npx
 import numpy as np
 from scipy import optimize
+
+# backwards compatibility (autograd < ???)
+import warnings  # ruff: isort: skip
+
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message=r"numpy.core.einsumfunc is deprecated",
+        category=DeprecationWarning,
+    )
+    # Importing autograd can raise deprecation warnings depending on
+    # the version of autograd and numpy. For example, autograd 1.7.0
+    # and numpy == 2.0.2 give a deprecation warning on import.
+    from autograd import numpy as npx
+
 
 # test functions
 

--- a/tests/experiments/test_analytic.py
+++ b/tests/experiments/test_analytic.py
@@ -2,12 +2,25 @@
 
 import unittest
 
-from autograd import numpy as npx
 import numpy as np
 import pytest
 
 from experiments import analytic, simulation
 from opda import nonparametric, parametric, utils
+
+# backwards compatibility (autograd < ???)
+import warnings  # ruff: isort: skip
+
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message=r"numpy.core.einsumfunc is deprecated",
+        category=DeprecationWarning,
+    )
+    # Importing autograd can raise deprecation warnings depending on
+    # the version of autograd and numpy. For example, autograd 1.7.0
+    # and numpy == 2.0.2 give a deprecation warning on import.
+    from autograd import numpy as npx
 
 
 class EllipseVolumeTestCase(unittest.TestCase):


### PR DESCRIPTION
Suppress expected warnings from the `autograd` package in the optional dependencies: `experiments`.