### PR TITLE
Fix support session to mention updating setup docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,8 +56,10 @@ The format is based on `Keep a Changelog
 
 .. rubric:: Fixes
 
-* Fix support policy check in continuous integration so that it
-  more accurately determines currently supported python versions.
+* Fix the support policy check in continuous integration:
+
+  * Determine currently supported python versions more correctly.
+  * Mention updating the setup documentation when versions change.
 
 * Suppress expected deprecation warnings that ``autograd`` fires when
   installed with certain versions of ``numpy``.

--- a/noxfile.py
+++ b/noxfile.py
@@ -297,6 +297,10 @@ def support(session):
             f"ADD Python {python_version} to SUPPORTED_PYTHON_VERSIONS"
             f" in noxfile.py.",
         )
+        maintenance_actions.append(
+            f"ADD Python {python_version} to versions discussed in"
+            f" docs/tutorial/setup.rst.",
+        )
     for python_version in (
             SUPPORTED_PYTHON_VERSIONS - policy_python_versions
     ):
@@ -307,6 +311,10 @@ def support(session):
         maintenance_actions.append(
             f"DROP Python {python_version} from SUPPORTED_PYTHON_VERSIONS"
             f" in noxfile.py.",
+        )
+        maintenance_actions.append(
+            f"DROP Python {python_version} from versions discussed in"
+            f" docs/tutorial/setup.rst.",
         )
         maintenance_actions.append(
             "UPDATE .default-python-version file.",


### PR DESCRIPTION
Mention the need to update the setup documentation when support for a new python version is added or removed.