### PR TITLE
Use SPDX license expression for license

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,6 +83,12 @@ The format is based on `Keep a Changelog
   * Rename ``data/resnet/resnet18_scaling.results.jsonl`` to
     ``data/resnet/resnet18_tuning.results.jsonl``.
 
+* Upgrade packaging tools to ``setuptools >= 77.0``,
+  ``build == 1.2.2``,  and ``twine == 6.1.0``.
+* Specify license using an SPDX license expression for
+  ``project.license`` in ``pyproject.toml`` instead of the classifier:
+  ``License :: OSI Approved :: Apache Software License``.
+
 .. rubric:: Deprecations
 .. rubric:: Removals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.7.0"
 authors = [{ name = "Nicholas Lourie", email = "dev@nicholaslourie.com" }]
 description = "Design and analyze optimal deep learning models."
 readme = "README.rst"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 requires-python = ">= 3.9"
 dependencies = [
   "numpy >= 1.24",
@@ -26,7 +26,6 @@ keywords = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ test = [
   "pytest == 7.4.4",
 ]
 package = [
-  "build == 1.2.1",
+  "build == 1.2.2",
   "twine == 6.1.0",
 ]
 ci = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools >= 77.0"]
 build-backend = "setuptools.build_meta"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ test = [
 ]
 package = [
   "build == 1.2.1",
-  "twine == 5.1.1",
+  "twine == 6.1.0",
 ]
 ci = [
   "lxml == 5.3.0",


### PR DESCRIPTION
Newer versions of `setuptools` deprecate using classifiers and TOML tables in `project.license` as ways of specifying the license. Instead, migrate to SPDX license expressions.