### PR TITLE
Fix `fit` methods when all `ys` are negative

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -114,6 +114,9 @@ The format is based on `Keep a Changelog
 * Make ``opda.parametric.NoisyQuadraticDistribution.fit`` optimize
   more robustly.
 * Fix flakiness in various tests.
+* Fix an error thrown by ``opda.parametric.QuadraticDistribution.fit``
+  and ``opda.parametric.NoisyQuadraticDistribution.fit`` when all
+  ``ys`` are negative.
 
 .. rubric:: Documentation
 

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -2490,7 +2490,7 @@ class NoisyQuadraticDistribution:
                 # decimals to stay within those representable by the
                 # floating point format.
                 decimals = - np.clip(
-                    np.log10(np.max(np.spacing(ys_observed))),
+                    np.log10(np.max(np.abs(np.spacing(ys_observed)))),
                     np.log10(finfo.smallest_normal),
                     np.log10(finfo.max),
                 ).astype(int) - 3

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -981,7 +981,7 @@ class QuadraticDistribution:
                 # decimals to stay within those representable by the
                 # floating point format.
                 decimals = - np.clip(
-                    np.log10(np.max(np.spacing(ys_observed))),
+                    np.log10(np.max(np.abs(np.spacing(ys_observed)))),
                     np.log10(finfo.smallest_normal),
                     np.log10(finfo.max),
                 ).astype(int) - 3

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -1567,6 +1567,35 @@ class QuadraticDistributionTestCase(testcases.RandomTestCase):
             ),
         )
 
+    @pytest.mark.level(1)
+    def test_fit_when_all_ys_are_negative(self):
+        n_samples = 8
+
+        # Due to the small sample size, fit might estimate that c = 2,
+        # in which case it will fire a warning about identifiability.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"Parameters might be unidentifiable.",
+                category=RuntimeWarning,
+            )
+
+            # Test when a = b.
+            ys = [-1.] * n_samples
+            parametric.QuadraticDistribution.fit(
+                ys,
+                method="maximum_spacing",
+            )
+
+            # Test when a != b.
+            ys = parametric.QuadraticDistribution(
+                -2., -1., 1, False,
+            ).sample(n_samples)
+            parametric.QuadraticDistribution.fit(
+                ys,
+                method="maximum_spacing",
+            )
+
 
 class NoisyQuadraticDistributionTestCase(testcases.RandomTestCase):
     """Test opda.parametric.NoisyQuadraticDistribution."""

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -3885,6 +3885,7 @@ class NoisyQuadraticDistributionTestCase(testcases.RandomTestCase):
         self.assertEqual(dist_hat.c, c)
         self.assertEqual(dist_hat.convex, convex)
 
+    @pytest.mark.level(2)
     def test_fit_accepts_integer_data(self):
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -3981,3 +3981,32 @@ class NoisyQuadraticDistributionTestCase(testcases.RandomTestCase):
                 ys, generator=np.random.default_rng(0),
             ),
         )
+
+    @pytest.mark.level(3)
+    def test_fit_when_all_ys_are_negative(self):
+        n_samples = 8
+
+        # Due to the small sample size, fit might estimate that c = 2,
+        # in which case it will fire a warning about identifiability.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"Parameters might be unidentifiable.",
+                category=RuntimeWarning,
+            )
+
+            # Test when a = b and o = 0.
+            ys = [-1.] * n_samples
+            parametric.NoisyQuadraticDistribution.fit(
+                ys,
+                method="maximum_spacing",
+            )
+
+            # Test when a != b and o > 0.
+            ys = parametric.NoisyQuadraticDistribution(
+                -2., -1., 1, 1e-2, False,
+            ).sample(n_samples)
+            parametric.NoisyQuadraticDistribution.fit(
+                ys,
+                method="maximum_spacing",
+            )


### PR DESCRIPTION
When all `ys` are negative, `QuadraticDistribution.fit` and `NoisyQuadraticDistribution.fit` throw an error when they should not. Fix the error and add a regression test for it.