### PR TITLE
Allow censored infinities in `fit`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -85,6 +85,11 @@ The format is based on `Keep a Changelog
   * Add the data itself: ``data/llama/llama-33m_residual.results.jsonl``.
   * Update its README to describe the data: ``data/llama/README.md``.
 
+* Make ``opda.parametric.QuadraticDistribution.fit`` and
+  ``opda.parametric.NoisyQuadraticDistribution.fit`` accept infinite
+  observations in ``ys`` if those observations are censored by
+  ``limits``.
+
 .. rubric:: Changes
 
 * Rename hyperparameter tuning results files:

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -426,7 +426,7 @@ class QuadraticDistribution:
 
         Parameters
         ----------
-        ys : 1D array of finite floats, required
+        ys : 1D array of floats, required
             The sample from the distribution.
         limits : pair of floats, optional
             The left-open interval over which to fit the distribution.
@@ -616,8 +616,12 @@ class QuadraticDistribution:
             raise ValueError(f"ys must be a 1D array, not {len(ys.shape)}D.")
         if len(ys) == 0:
             raise ValueError("ys must be non-empty.")
-        if not np.all(np.isfinite(ys)):
-            raise ValueError("ys must only contain finite floats.")
+        if limits[0] == -np.inf and np.any(np.isneginf(ys)):
+            raise ValueError("ys must not contain -inf unless it is censored.")
+        if limits[1] == np.inf and np.any(np.isposinf(ys)):
+            raise ValueError("ys must not contain inf unless it is censored.")
+        if np.any(np.isnan(ys)):
+            raise ValueError("ys must not contain NaN.")
         if np.issubdtype(ys.dtype, np.integer):
             # Only cast ys if it has an integer data type, otherwise
             # preserve its precision which we'll need later in order

--- a/src/opda/parametric.py
+++ b/src/opda/parametric.py
@@ -1798,7 +1798,7 @@ class NoisyQuadraticDistribution:
 
         Parameters
         ----------
-        ys : 1D array of finite floats, required
+        ys : 1D array of floats, required
             The sample from the distribution.
         limits : pair of floats, optional
             The left-open interval over which to fit the distribution.
@@ -2059,8 +2059,12 @@ class NoisyQuadraticDistribution:
             raise ValueError(f"ys must be a 1D array, not {len(ys.shape)}D.")
         if len(ys) == 0:
             raise ValueError("ys must be non-empty.")
-        if not np.all(np.isfinite(ys)):
-            raise ValueError("ys must only contain finite floats.")
+        if limits[0] == -np.inf and np.any(np.isneginf(ys)):
+            raise ValueError("ys must not contain -inf unless it is censored.")
+        if limits[1] == np.inf and np.any(np.isposinf(ys)):
+            raise ValueError("ys must not contain inf unless it is censored.")
+        if np.any(np.isnan(ys)):
+            raise ValueError("ys must not contain NaN.")
         if np.issubdtype(ys.dtype, np.integer):
             # Only cast ys if it has an integer data type, otherwise
             # preserve its precision which we'll need later in order

--- a/tests/opda/test_parametric.py
+++ b/tests/opda/test_parametric.py
@@ -4069,3 +4069,68 @@ class NoisyQuadraticDistributionTestCase(testcases.RandomTestCase):
                 ys,
                 method="maximum_spacing",
             )
+
+    @pytest.mark.level(1)
+    def test_fit_with_censored_infinity(self):
+        n_samples = 2_048
+
+        a, b, c, o, convex = 0., 1., 2, 4e-2, False
+        dist = parametric.NoisyQuadraticDistribution(a, b, c, o, convex)
+        ys = dist.sample(n_samples)
+
+        # NOTE: Use constraints in fit below to make fit run faster.
+
+        # Test when ys contains inf.
+        #   positive infinitiy
+        with self.assertRaises(ValueError):
+            parametric.NoisyQuadraticDistribution.fit(
+                ys=np.concatenate([[np.inf], ys]),
+                limits=(-np.inf, np.inf),
+                constraints={"c": c, "convex": convex},
+            )
+        #   negative infinitiy
+        with self.assertRaises(ValueError):
+            parametric.NoisyQuadraticDistribution.fit(
+                ys=np.concatenate([[-np.inf], ys]),
+                limits=(-np.inf, np.inf),
+                constraints={"c": c, "convex": convex},
+            )
+        #   both positive and negative infinity
+        with self.assertRaises(ValueError):
+            parametric.NoisyQuadraticDistribution.fit(
+                ys=np.concatenate([[-np.inf, np.inf], ys]),
+                limits=(-np.inf, np.inf),
+                constraints={"c": c, "convex": convex},
+            )
+
+        # Test when ys contains inf but it is censored.
+        #   positive infinitiy
+        dist_hat = parametric.NoisyQuadraticDistribution.fit(
+            ys=np.concatenate([[np.inf], ys]),
+            limits=(-np.inf, b),
+            constraints={"c": c, "convex": convex},
+        )
+        self.assertAlmostEqual(dist_hat.a, a, delta=5e-2 * (b - a) + o)
+        self.assertAlmostEqual(dist_hat.b, b, delta=5e-2 * (b - a) + o)
+        self.assertGreaterEqual(dist_hat.o, o / 5.)
+        self.assertLessEqual(dist_hat.o, 5. * o)
+        #   negative infinitiy
+        dist_hat = parametric.NoisyQuadraticDistribution.fit(
+            ys=np.concatenate([[-np.inf], ys]),
+            limits=(a, np.inf),
+            constraints={"c": c, "convex": convex},
+        )
+        self.assertAlmostEqual(dist_hat.a, a, delta=5e-2 * (b - a) + o)
+        self.assertAlmostEqual(dist_hat.b, b, delta=5e-2 * (b - a) + o)
+        self.assertGreaterEqual(dist_hat.o, o / 5.)
+        self.assertLessEqual(dist_hat.o, 5. * o)
+        #   both positive and negative infinity
+        dist_hat = parametric.NoisyQuadraticDistribution.fit(
+            ys=np.concatenate([[-np.inf, np.inf], ys]),
+            limits=(a, b),
+            constraints={"c": c, "convex": convex},
+        )
+        self.assertAlmostEqual(dist_hat.a, a, delta=5e-2 * (b - a) + o)
+        self.assertAlmostEqual(dist_hat.b, b, delta=5e-2 * (b - a) + o)
+        self.assertGreaterEqual(dist_hat.o, o / 5.)
+        self.assertLessEqual(dist_hat.o, 5. * o)


### PR DESCRIPTION
Allow infinite observations in `ys` when they are censored by the `limits` argument for `QuadraticDistribution.fit` and `NoisyQuadraticDistribution.fit`.